### PR TITLE
build(deps): move from faust to faust-streaming and freeze other deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django
-djangorestframework
+django==3.1.13
+djangorestframework==3.13.1
 pyjwt==2.1.0
-requests
-drf_spectacular
-faust==1.10.4
+requests==2.27.1
+drf_spectacular==0.21.1
+faust-streaming==0.8.1


### PR DESCRIPTION
1. faust is no longer maintained by robinhood, it would be better to move to a community maintained fork, faust-streaming.

> No new release since long time
> https://pypi.org/project/faust/#history 
> https://pypi.org/project/robinhood-aiokafka/#history 
> 
> Not actively maintained
> https://github.com/robinhood/faust/issues/707 
> https://github.com/robinhood/faust/issues/692 
> 
> Issue with exiting
> https://github.com/robinhood/faust/issues/711 
> https://github.com/robinhood/faust/issues/484 
> 
> Not restarting on kafka down
> https://github.com/robinhood/faust/issues/596 
> 
> Community maintained fork
> https://github.com/robinhood/faust/issues/685 
> https://github.com/faust-streaming/faust 
> https://pypi.org/project/faust-streaming/#history 

2. deps should be freezed I think, maybe it is better to allow some specific ranges like (>=0.3, <0.4) in order to not have clashes with projects that install this package.